### PR TITLE
Mistake in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ if you want be more awsome, use \<snipmate\> and \<vim-snipmate-ruby-snippets\>:
 install:
 ```
 git clone https://github.com/kaichen/vim-snipmate-ruby-snippets.git
-cp vim-snipmate-ruby-snippets/*.snippnets ~/.vim/bundle/snipmate.vim/snippets/
+cp vim-snipmate-ruby-snippets/*.snippets ~/.vim/bundle/snipmate.vim/snippets/
 
 then restart your vim.
 ```


### PR DESCRIPTION
There was a mistake in the readme for installing snipmate, an extra n in "snippets" in the copy command under the Extra section. Otherwise this is a decent instruction and .vimrc, going to try and meddle around with it for a bit :)
